### PR TITLE
feat:HTTP 前端參數樣板

### DIFF
--- a/frontend/src/components/scheduler/TaskForm.vue
+++ b/frontend/src/components/scheduler/TaskForm.vue
@@ -101,15 +101,57 @@
               />
             </v-col>
             <v-col cols="12" md="6">
-              <v-textarea
-                v-model="httpHeadersText"
-                label="Headers (JSON)"
-                @blur="formatHeaders"
-                variant="outlined"
-                rows="2"
-                :error-messages="httpHeadersError ? [httpHeadersError] : []"
-                placeholder='{"Accept": "application/json"}'
-              />
+              <div style="position: relative">
+                <div
+                  class="font-weight-bold"
+                  style="position: absolute; top: -24px; left: 0"
+                >
+                  HTTP Headers
+                </div>
+                <div
+                  v-for="(row, idx) in headerRows"
+                  :key="idx"
+                  class="d-flex align-center mb-2"
+                  style="margin-top: 0px"
+                >
+                  <v-combobox
+                    v-model="row.key"
+                    :items="commonHeaders"
+                    label="Key"
+                    variant="outlined"
+                    density="compact"
+                    class="mr-2"
+                    clearable
+                    hide-details
+                    style="max-width: 220px"
+                    filterable
+                    solo
+                  />
+                  <v-text-field
+                    v-model="row.value"
+                    label="Value"
+                    variant="outlined"
+                    density="compact"
+                    hide-details
+                    style="max-width: 220px"
+                  />
+                  <v-btn
+                    icon="mdi-delete"
+                    @click="headerRows.splice(idx, 1)"
+                    v-if="headerRows.length > 1"
+                    size="small"
+                    variant="text"
+                  />
+                </div>
+                <v-btn
+                  color="primary"
+                  variant="text"
+                  @click="headerRows.push({ key: '', value: '' })"
+                  size="small"
+                >
+                  <v-icon>mdi-plus</v-icon> 新增 Header
+                </v-btn>
+              </div>
             </v-col>
             <v-col cols="12">
               <v-textarea
@@ -191,6 +233,34 @@ const httpHeadersError = ref("");
 const httpBodyText = ref("");
 const httpBodyError = ref("");
 
+// HTTP Headers 欄位
+const headerRows = ref([{ key: "", value: "" }]);
+const commonHeaders = [
+  "Authorization",
+  "Host",
+  "Accept-Language",
+  "Accept-Encoding",
+  "Cookie",
+  "Cache-Control",
+  "Content-Length",
+  "Content-Type",
+  "Accept",
+  "Referer",
+  "User-Agent",
+  "WWW-Authenticate",
+  "Proxy-Authenticate",
+  "Proxy-Authorization",
+  "Age",
+];
+// 組合 headers 物件
+const getHeadersObject = () => {
+  const obj: Record<string, string> = {};
+  headerRows.value.forEach((row) => {
+    if (row.key) obj[row.key] = row.value;
+  });
+  return obj;
+};
+
 const formData = ref({
   name: "",
   description: "",
@@ -262,36 +332,24 @@ watch(
 
 // 監聽 HTTP 欄位變化
 watch(
-  [httpMethod, httpHeadersText, httpBodyText],
+  [httpMethod, headerRows, httpBodyText],
   ([method, headers, body]) => {
     if (formData.value.target_type === "http") {
-      let headersObj = {};
       let bodyObj = {};
-      httpHeadersError.value = "";
-      httpBodyError.value = "";
-      // 檢查 headers
-      if (headers.trim()) {
-        try {
-          headersObj = JSON.parse(headers);
-        } catch (e) {
-          httpHeadersError.value = "Headers 格式錯誤: " + e.message;
-        }
-      }
-      // 檢查 body
+
       if (body.trim()) {
         try {
           bodyObj = JSON.parse(body);
-        } catch (e) {
-          httpBodyError.value = "Body 格式錯誤: " + e.message;
-        }
+        } catch (e) {}
       }
       formData.value.target_input = {
         method,
-        headers: headersObj,
+        headers: getHeadersObject(),
         body: bodyObj,
       };
     }
-  }
+  },
+  { deep: true }
 );
 
 // 監聽 target_input 變化 (非 HTTP 類型)
@@ -347,26 +405,80 @@ defineExpose({
   setScheduleExpression,
 });
 
-// HTTP Headers/Body Formatters
-const formatHeaders = () => {
-  if (!httpHeadersText.value.trim()) return;
-  try {
-    const obj = JSON.parse(httpHeadersText.value);
-    httpHeadersText.value = JSON.stringify(obj, null, 2);
-    httpHeadersError.value = "";
-  } catch (e: any) {
-    httpHeadersError.value = "Headers 格式錯誤: " + e.message;
-  }
-};
-
 const formatBody = () => {
-  if (!httpBodyText.value.trim()) return;
+  let text = httpBodyText.value.trim();
+
+  // 如果是空的，清空錯誤內容
+  if (!text) {
+    httpBodyError.value = "";
+    httpBodyText.value = "";
+    return;
+  }
+
+  // 如果只輸入 { 或 "，自動補齊為 {} 或 ""
+  if (text === "{") {
+    httpBodyText.value = "{}";
+    httpBodyError.value = "";
+    return;
+  }
+
+  if (text === '"') {
+    httpBodyText.value = '""';
+    httpBodyError.value = "";
+    return;
+  }
+
+  // 嘗試解析 JSON，成功則格式化並清除錯誤
   try {
-    const obj = JSON.parse(httpBodyText.value);
+    const obj = JSON.parse(text);
+    httpBodyText.value = JSON.stringify(obj, null, 2);
+    httpBodyError.value = "";
+    return;
+  } catch (e) {
+    // 解析失敗，進入自動補齊流程
+  }
+
+  // 自動補齊：補引號、括號
+  let modifiedText = text;
+
+  // 計算引號數量
+  const unescapedQuotes = text.replace(/\\"/g, "").match(/"/g) || [];
+  const quoteCount = unescapedQuotes.length;
+
+  // 檢查是否為未結束的 value 字串（如 {"key":"value)
+  // 如果引號數量為奇數且最後一個引號前是冒號，補上右引號
+  if (quoteCount % 2 === 1) {
+    const lastQuoteIndex = text.lastIndexOf('"');
+    let isValueStart = false;
+    for (let i = lastQuoteIndex - 1; i >= 0; i--) {
+      if (text[i] === " " || text[i] === "\n" || text[i] === "\t") continue;
+      if (text[i] === ":") {
+        isValueStart = true;
+        break;
+      }
+      break;
+    }
+    if (isValueStart) {
+      modifiedText += '"';
+    }
+  }
+
+  // 計算補齊後的括號數量
+  const modLeftBraces = (modifiedText.match(/{/g) || []).length;
+  const modRightBraces = (modifiedText.match(/}/g) || []).length;
+  // 補齊缺少的 }
+  const missingBraces = modLeftBraces - modRightBraces;
+  if (missingBraces > 0) {
+    modifiedText += "}".repeat(missingBraces);
+  }
+  // 再次嘗試解析補齊後的內容，成功則格式化，失敗則顯示錯誤並保留原始內容
+  try {
+    const obj = JSON.parse(modifiedText);
     httpBodyText.value = JSON.stringify(obj, null, 2);
     httpBodyError.value = "";
   } catch (e: any) {
     httpBodyError.value = "Body 格式錯誤: " + e.message;
+    httpBodyText.value = text;
   }
 };
 </script>

--- a/frontend/src/components/scheduler/TaskForm.vue
+++ b/frontend/src/components/scheduler/TaskForm.vue
@@ -87,15 +87,55 @@
               density="compact"
             />
           </v-col>
-          <v-col cols="12">
-            <v-textarea
-              v-model="targetInputText"
-              label="目標輸入參數 (JSON)"
-              variant="outlined"
-              rows="4"
-              placeholder='{"method": "GET", "headers": {"Accept": "application/json"}}'
-            />
-          </v-col>
+          <!-- HTTP 類型時顯示 Method、Header、Body -->
+          <template v-if="formData.target_type === 'http'">
+            <v-col cols="12" md="6">
+              <v-select
+                v-model="httpMethod"
+                :items="httpMethodOptions"
+                label="HTTP Method"
+                variant="outlined"
+                density="compact"
+                :rules="[rules.required]"
+                required
+              />
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-textarea
+                v-model="httpHeadersText"
+                label="Headers (JSON)"
+                @blur="formatHeaders"
+                variant="outlined"
+                rows="2"
+                :error-messages="httpHeadersError ? [httpHeadersError] : []"
+                placeholder='{"Accept": "application/json"}'
+              />
+            </v-col>
+            <v-col cols="12">
+              <v-textarea
+                v-model="httpBodyText"
+                label="HTTP Body (JSON)"
+                @blur="formatBody"
+                variant="outlined"
+                rows="4"
+                :error-messages="httpBodyError ? [httpBodyError] : []"
+                placeholder='{"key": "value"}'
+              />
+            </v-col>
+          </template>
+          <!-- 其他類型維持原本 target_input 輸入 -->
+          <template v-else>
+            <v-col cols="12">
+              <v-textarea
+                v-model="targetInputText"
+                label="目標輸入參數 (JSON)"
+                variant="outlined"
+                rows="4"
+                placeholder='{"method": "GET", "headers": {"Accept": "application/json"}}'
+                :error-messages="targetInputError ? [targetInputError] : []"
+              />
+            </v-col>
+          </template>
           <!-- 新增啟用開關 -->
           <v-col cols="12" md="6">
             <v-switch
@@ -141,6 +181,15 @@ const emit = defineEmits<{
 
 const formRef = ref();
 const targetInputText = ref("");
+const targetInputError = ref("");
+
+// HTTP Method 欄位
+const httpMethod = ref("GET");
+const httpMethodOptions = ["GET", "POST", "PUT", "DELETE", "PATCH"];
+const httpHeadersText = ref("");
+const httpHeadersError = ref("");
+const httpBodyText = ref("");
+const httpBodyError = ref("");
 
 const formData = ref({
   name: "",
@@ -188,11 +237,22 @@ watch(
           state:
             newData.state !== undefined ? newData.state : TaskState.ENABLED,
         };
-        targetInputText.value = JSON.stringify(
-          newData.target_input || {},
-          null,
-          2
-        );
+        // HTTP 類型時分解 method/headers/body
+        if (formData.value.target_type === "http") {
+          httpMethod.value = newData.target_input?.method || "GET";
+          httpHeadersText.value = newData.target_input?.headers
+            ? JSON.stringify(newData.target_input.headers, null, 2)
+            : "";
+          httpBodyText.value = newData.target_input?.body
+            ? JSON.stringify(newData.target_input.body, null, 2)
+            : "";
+        } else {
+          targetInputText.value = JSON.stringify(
+            newData.target_input || {},
+            null,
+            2
+          );
+        }
         console.log("TaskForm 更新後的 formData:", formData.value);
       });
     }
@@ -200,12 +260,49 @@ watch(
   { immediate: true, deep: true }
 );
 
-// 監聽 target_input 文本變化
+// 監聽 HTTP 欄位變化
+watch(
+  [httpMethod, httpHeadersText, httpBodyText],
+  ([method, headers, body]) => {
+    if (formData.value.target_type === "http") {
+      let headersObj = {};
+      let bodyObj = {};
+      httpHeadersError.value = "";
+      httpBodyError.value = "";
+      // 檢查 headers
+      if (headers.trim()) {
+        try {
+          headersObj = JSON.parse(headers);
+        } catch (e) {
+          httpHeadersError.value = "Headers 格式錯誤: " + e.message;
+        }
+      }
+      // 檢查 body
+      if (body.trim()) {
+        try {
+          bodyObj = JSON.parse(body);
+        } catch (e) {
+          httpBodyError.value = "Body 格式錯誤: " + e.message;
+        }
+      }
+      formData.value.target_input = {
+        method,
+        headers: headersObj,
+        body: bodyObj,
+      };
+    }
+  }
+);
+
+// 監聽 target_input 變化 (非 HTTP 類型)
 watch(targetInputText, (newValue) => {
-  try {
-    formData.value.target_input = newValue ? JSON.parse(newValue) : {};
-  } catch (error) {
-    // JSON 格式錯誤，保持原值
+  if (formData.value.target_type !== "http") {
+    targetInputError.value = "";
+    try {
+      formData.value.target_input = newValue ? JSON.parse(newValue) : {};
+    } catch (error: any) {
+      targetInputError.value = "JSON 格式錯誤: " + error.message;
+    }
   }
 });
 
@@ -216,6 +313,12 @@ const openScheduleWizard = () => {
 
 const handleSubmit = async () => {
   const { valid } = await formRef.value.validate();
+  // 檢查 JSON 欄位錯誤
+  if (formData.value.target_type === "http") {
+    if (httpHeadersError.value || httpBodyError.value) return;
+  } else {
+    if (targetInputError.value) return;
+  }
   if (valid) {
     const payload = {
       ...formData.value,
@@ -243,4 +346,27 @@ const setScheduleExpression = (expression: string) => {
 defineExpose({
   setScheduleExpression,
 });
+
+// HTTP Headers/Body Formatters
+const formatHeaders = () => {
+  if (!httpHeadersText.value.trim()) return;
+  try {
+    const obj = JSON.parse(httpHeadersText.value);
+    httpHeadersText.value = JSON.stringify(obj, null, 2);
+    httpHeadersError.value = "";
+  } catch (e: any) {
+    httpHeadersError.value = "Headers 格式錯誤: " + e.message;
+  }
+};
+
+const formatBody = () => {
+  if (!httpBodyText.value.trim()) return;
+  try {
+    const obj = JSON.parse(httpBodyText.value);
+    httpBodyText.value = JSON.stringify(obj, null, 2);
+    httpBodyError.value = "";
+  } catch (e: any) {
+    httpBodyError.value = "Body 格式錯誤: " + e.message;
+  }
+};
 </script>


### PR DESCRIPTION
# **這支 PR 所做的事情**

盡可能詳細取代本文字。 Replace this text and describe This PR doing(Better to be detail)

- feat: targetType選擇HTTP時，可以讓使用者選 Method，Header 跟 Body 分成兩個 Field，有 JSON Formatter：

```json
{ "Accept" :"Application/JSON"}
```
會變成：
```json
{
     "Accept" :"Application/JSON"
}
```
## 所屬 Issue

- Related Issues 相關的 Issues : https://github.com/fan9704/EScheduler/issues/25

---

## 變更的類型 Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 影響的 API Affect API

- [ ] Team
- [x] 不影響 API No affect API
- [ ] 其他（請填寫） Other(Please enter it)


## 檢查清單 Check List

- [x] 我已經在本地手動測試過，確保功能的完整性和穩定性 I have done fully correct manual test
- [x] 我對我的程式碼進行了註解，特別是在難以理解的地方 I have added comment in my code
- [x] 我已經更新了文件，或者我的更改不需要更新文件 I have commented in document
- [x] 我的 PR 有明確的標題與內容描述 My PR has right title and description

## 相關的資源或參考文件連結 Related Resource/Document Link

If this PR related some resource/document please offer link
