### PR TITLE
fix: ExecutionResult data only RabbitMQResult

### DIFF
--- a/src/models/pydantic/strategy.py
+++ b/src/models/pydantic/strategy.py
@@ -5,19 +5,42 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field
 from src.configs.cfg import TZ
 
-class RabbitMQResult(BaseModel):
-    """RabbitQM結果封裝"""
+class BaseResult(BaseModel):
+    """所有 Result 的基底"""
+    pass
+
+class RabbitMQResult(BaseResult):
+    """RabbitQM 結果封裝"""
     target: str = Field(..., description="目標 Queue 或 Exchange 資訊")
     message_body: Dict[str, Any] = Field(..., description="訊息內容")
     properties: Dict[str, Any] = Field(default_factory=dict, description="訊息屬性 (如 TTL, Priority)")
     queue_args: Dict[str, Any] = Field(default_factory=dict, description="Queue 參數 (如死信, 最大優先級)")
     message_size: int = Field(..., description="訊息大小 (bytes)")
 
+class HTTPResult(BaseResult):
+    """HTTP 結果封裝"""
+    method: str = Field(..., description="HTTP 方法 (GET, POST, ...)")
+    url: str = Field(..., description="請求的 URL")
+    request_headers: Dict[str, Any] = Field(default_factory=dict, description="請求標頭")
+    request_params: Dict[str, Any] = Field(default_factory=dict, description="查詢參數")
+    request_data: Optional[Any] = Field(None, description="請求資料 (POST body, JSON, ...)")
+    response_body: Optional[str] = Field(None, description="回應內容 (純文字/JSON字串)")
+    response_headers: Dict[str, Any] = Field(default_factory=dict, description="回應標頭")
+
+class WebhookResult(BaseResult):
+    """Webhook 結果封裝"""
+    method: str = Field(..., description="HTTP 方法 (POST, GET, ...)")
+    url: str = Field(..., description="Webhook 目標 URL")
+    body: Optional[Any] = Field(None, description="請求的主體內容 (JSON 或字串)")
+    has_signature: bool = Field(False, description="是否包含簽名驗證 (取決於 secret)")
+    response_body: Optional[str] = Field(None, description="Webhook 回應內容")
+    response_headers: Dict[str, Any] = Field(default_factory=dict, description="Webhook 回應標頭")
+
 class ExecutionResult(BaseModel):
     """執行結果封裝類"""
     success: bool = Field(..., description="是否成功")
     message: str = Field(..., description="訊息內容")
-    data: RabbitMQResult = Field(default_factory=RabbitMQResult, description="附加資料")
+    data: Optional[BaseResult] = Field(default_factory=None, description="附加資料")
     execution_time: float = Field(default=0.0, description="執行時間（秒）")
     status_code: Optional[int] = Field(default=None, description="狀態碼")
     timestamp: datetime = Field(default_factory=lambda: datetime.now(ZoneInfo(TZ)), description="時間戳")

--- a/src/models/pydantic/strategy.py
+++ b/src/models/pydantic/strategy.py
@@ -5,11 +5,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field
 from src.configs.cfg import TZ
 
-class BaseResult(BaseModel):
+class StrategyBaseResult(BaseModel):
     """所有 Result 的基底"""
     pass
 
-class RabbitMQResult(BaseResult):
+class RabbitMQResult(StrategyBaseResult):
     """RabbitQM 結果封裝"""
     target: str = Field(..., description="目標 Queue 或 Exchange 資訊")
     message_body: Dict[str, Any] = Field(..., description="訊息內容")
@@ -17,7 +17,7 @@ class RabbitMQResult(BaseResult):
     queue_args: Dict[str, Any] = Field(default_factory=dict, description="Queue 參數 (如死信, 最大優先級)")
     message_size: int = Field(..., description="訊息大小 (bytes)")
 
-class HTTPResult(BaseResult):
+class HTTPResult(StrategyBaseResult):
     """HTTP 結果封裝"""
     method: str = Field(..., description="HTTP 方法 (GET, POST, ...)")
     url: str = Field(..., description="請求的 URL")
@@ -27,7 +27,7 @@ class HTTPResult(BaseResult):
     response_body: Optional[str] = Field(None, description="回應內容 (純文字/JSON字串)")
     response_headers: Dict[str, Any] = Field(default_factory=dict, description="回應標頭")
 
-class WebhookResult(BaseResult):
+class WebhookResult(StrategyBaseResult):
     """Webhook 結果封裝"""
     method: str = Field(..., description="HTTP 方法 (POST, GET, ...)")
     url: str = Field(..., description="Webhook 目標 URL")
@@ -40,7 +40,7 @@ class ExecutionResult(BaseModel):
     """執行結果封裝類"""
     success: bool = Field(..., description="是否成功")
     message: str = Field(..., description="訊息內容")
-    data: Optional[BaseResult] = Field(default_factory=None, description="附加資料")
+    data: Optional[StrategyBaseResult] = Field(default_factory=None, description="附加資料")
     execution_time: float = Field(default=0.0, description="執行時間（秒）")
     status_code: Optional[int] = Field(default=None, description="狀態碼")
     timestamp: datetime = Field(default_factory=lambda: datetime.now(ZoneInfo(TZ)), description="時間戳")

--- a/src/services/execution_strategies/http_strategy.py
+++ b/src/services/execution_strategies/http_strategy.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from typing import Dict, Any
 from . import ExecutionStrategy
-from src.models.pydantic.strategy import ExecutionResult
+from src.models.pydantic.strategy import ExecutionResult, HTTPResult
 
 logger = logging.getLogger(__name__)
 
@@ -58,19 +58,20 @@ class HttpExecutionStrategy(ExecutionStrategy):
                         logger.info(f"HTTP 回應內容: {response_text[:200]}...")  # 只記錄前200字符
                         
                         success = 200 <= response.status < 300
+                        http_result = HTTPResult(
+                            method=method,
+                            url=str(response.url),
+                            request_headers=default_headers,
+                            request_params=params,
+                            request_data=data,
+                            response_body=response_text,
+                            response_headers=dict(response.headers)
+                        )
                         
                         return ExecutionResult(
                             success=success,
                             message=f"HTTP {method} 請求{'成功' if success else '失敗'} (狀態碼: {response.status})",
-                            data={
-                                'method': method,
-                                'url': str(response.url),
-                                'request_headers': default_headers,
-                                'request_params': params,
-                                'request_data': data,
-                                'response_body': response_text,
-                                'response_headers': dict(response.headers)
-                            },
+                            data=http_result,
                             execution_time=execution_time,
                             status_code=response.status
                         )

--- a/src/services/execution_strategies/webhook_strategy.py
+++ b/src/services/execution_strategies/webhook_strategy.py
@@ -4,7 +4,7 @@ import logging
 import json
 from typing import Dict, Any
 from . import ExecutionStrategy
-from src.models.pydantic.strategy import ExecutionResult
+from src.models.pydantic.strategy import ExecutionResult, WebhookResult
 
 logger = logging.getLogger(__name__)
 
@@ -65,20 +65,21 @@ class WebhookExecutionStrategy(ExecutionStrategy):
                 ) as response:
                     response_text = await response.text()
                     execution_time = asyncio.get_event_loop().time() - start_time
-                    print(response.status, response_text)
+
                     success = 200 <= response.status < 300
-                    
+                    webhook_result = WebhookResult(
+                        method=method,
+                        url=str(response.url),
+                        body=body,
+                        has_signature=bool(secret),
+                        response_body=response_text,
+                        response_headers=dict(response.headers)
+                    )
+
                     return ExecutionResult(
                         success=success,
                         message=f"Webhook 調用{'成功' if success else '失敗'}",
-                        data={
-                            'method': method,
-                            'url': str(response.url),
-                            'body': body,
-                            'has_signature': bool(secret),
-                            'response_body': response_text,
-                            'response_headers': dict(response.headers)
-                        },
+                        data=webhook_result,
                         execution_time=execution_time,
                         status_code=response.status
                     )


### PR DESCRIPTION
# **這支 PR 所做的事情**

- 修復 `ExecutionResult` data限定 `RabbitMQResult` 的問題
- 並新增其他 strategy 的 `result pydantic`


## 所屬 Issue
#28 

---

## API 相關資訊

- Use Protocol 使用的通訊協定: [HTTP/Websocket]
- API Route API 路由: http://127.0.0.1:8000/api/xx
- Simple Test Method 提供簡單的測試方法:

### 範例 Request JSON

```json
{
    "example" : "我是範例"
}
```

### 範例 Response JSON

```json
{
    "example" : "我是範例" 
}
```

---

## 變更的類型 Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 影響的 API Affect API

- [ ] Team
- [x] 不影響 API No affect API
- [ ] 其他（請填寫） Other(Please enter it)


## 檢查清單 Check List

- [x] 我已經在本地手動測試過，確保功能的完整性和穩定性 I have done fully correct manual test
- [x] 我對我的程式碼進行了註解，特別是在難以理解的地方 I have added comment in my code
- [ ] 我已經更新了文件，或者我的更改不需要更新文件 I have commented in document
- [x] 我的 PR 有明確的標題與內容描述 My PR has right title and description

## 相關的資源或參考文件連結 Related Resource/Document Link

If this PR related some resource/document please offer link
